### PR TITLE
Add segment decryption sample

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@bitmovin/player-web-x": "^10.0.0-beta.17"
+        "@bitmovin/player-web-x": "^10.0.0"
       },
       "devDependencies": {
         "@types/node": "^20.3.2",
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@bitmovin/player-web-x": {
-      "version": "10.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@bitmovin/player-web-x/-/player-web-x-10.0.0-beta.17.tgz",
-      "integrity": "sha512-zaZSWP9aJm6J18oIV9eGXeAbISb0Y5ZSqFQ3OFxLJwOvxean+gZj/n/QqtRfDQ6N+td7T3ryj/bevDFMUrZuNw=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bitmovin/player-web-x/-/player-web-x-10.0.0.tgz",
+      "integrity": "sha512-oPLigiedVChQu0d8MFaA0Gq7qVGPHUPBBp7SknM8vv1FH4UfL6rrHz0LBDl5laT+nZAEvz2L5G+1n+MKaf65fQ=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -7468,9 +7468,9 @@
       "dev": true
     },
     "@bitmovin/player-web-x": {
-      "version": "10.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@bitmovin/player-web-x/-/player-web-x-10.0.0-beta.17.tgz",
-      "integrity": "sha512-zaZSWP9aJm6J18oIV9eGXeAbISb0Y5ZSqFQ3OFxLJwOvxean+gZj/n/QqtRfDQ6N+td7T3ryj/bevDFMUrZuNw=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bitmovin/player-web-x/-/player-web-x-10.0.0.tgz",
+      "integrity": "sha512-oPLigiedVChQu0d8MFaA0Gq7qVGPHUPBBp7SknM8vv1FH4UfL6rrHz0LBDl5laT+nZAEvz2L5G+1n+MKaf65fQ=="
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "webpack-plugin-serve": "^1.6.0"
   },
   "dependencies": {
-    "@bitmovin/player-web-x": "^10.0.0-beta.17"
+    "@bitmovin/player-web-x": "^10.0.0"
   }
 }

--- a/src/examples/playlist/Playlist.package.ts
+++ b/src/examples/playlist/Playlist.package.ts
@@ -142,8 +142,8 @@ function activateSource(ctx: ContextWithState, currentSource: SourceReference, n
     return;
   }
 
-  ctx.effects.state.dispatch(currentSource.state.video.clear);
-  ctx.effects.state.dispatch(nextSource.state.video.set, videoElement);
+  ctx.effects.state.dispatch(currentSource.state.video.setElement, undefined);
+  ctx.effects.state.dispatch(nextSource.state.video.setElement, videoElement);
 }
 
 export default PlaylistPackage;

--- a/src/examples/segment-decryption/BackendRequestTask.ts
+++ b/src/examples/segment-decryption/BackendRequestTask.ts
@@ -1,0 +1,53 @@
+import { createTask } from '@bitmovin/player-web-x/playerx-framework-utils';
+import type { HttpRequestMethod, HttpResponseType } from '@bitmovin/player-web-x/types/packages/network/Types';
+
+import { backendResponseToEncryptionData } from './Conversion';
+import type { EncryptionDataAtom } from './EncryptionDataAtom';
+import type { EncryptionDataBackendResponse, SegmentDecryptorPackageContext } from './Types';
+
+function getRequestConfig() {
+  const endpoint =
+    'data:application/json;charset=utf-8;base64,ew0KICAiaXZCYXNlNjQiOiAiZEdoaGJtc2dlVzkxSUdadmNpQjFjdz09IiwNCiAgImtleUJhc2U2NCI6ICJhVzVuSUhCc1lYbGxjaUIzWldJZ2VBPT0iDQp9';
+
+  return {
+    url: endpoint,
+    method: 'GET' as HttpRequestMethod.GET,
+    responseType: 'json' as HttpResponseType.JSON,
+  };
+}
+
+async function fetchEncryptionData(context: SegmentDecryptorPackageContext) {
+  const networkTask = context.registry.get('network-task');
+  const requestConfig = getRequestConfig();
+
+  // Wait for a bit to simulate a slow backend request
+  // and allow for segment downloads to start in the
+  // background before the encryption data is available
+  await context.effects.timeout(context.abortSignal, 2000);
+
+  const response = await context.fork(networkTask, [requestConfig, undefined]);
+
+  return backendResponseToEncryptionData(response.body as EncryptionDataBackendResponse);
+}
+
+// A task that requests some decryption information,
+// which is needed to decrypt segments, from a backend
+// and then updates the `EncryptionDataAtom` with the
+// returned data.
+export const BackendRequestTask = createTask(
+  'backend-request-package',
+  async (encryptionDataAtom: EncryptionDataAtom, context: SegmentDecryptorPackageContext) => {
+    const { state } = context.effects;
+    const logger = context.registry.get('logger');
+    const { red, bold } = context.registry.get('utils').AnsiEscapeSequences;
+    const logPrefix = `[${bold(red('Backend'))}] `;
+
+    logger.log(logPrefix + `Requesting encryption data...`);
+
+    const encryptionData = await fetchEncryptionData(context);
+
+    logger.log(logPrefix + `Encryption data received:`, encryptionData);
+
+    state.dispatch(encryptionDataAtom.setValue, encryptionData);
+  },
+);

--- a/src/examples/segment-decryption/Conversion.ts
+++ b/src/examples/segment-decryption/Conversion.ts
@@ -1,0 +1,19 @@
+import type { EncryptionDataBackendResponse } from './Types';
+
+function base64ToArrayBuffer(base64: string) {
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(binaryString.length);
+
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+
+  return bytes;
+}
+
+export function backendResponseToEncryptionData(response: EncryptionDataBackendResponse) {
+  return {
+    key: base64ToArrayBuffer(response.keyBase64),
+    iv: base64ToArrayBuffer(response.ivBase64),
+  };
+}

--- a/src/examples/segment-decryption/Decryption.ts
+++ b/src/examples/segment-decryption/Decryption.ts
@@ -1,0 +1,6 @@
+import type { EncryptionData } from './EncryptionDataAtom';
+
+export async function decrypt(encrypted: Uint8Array, _encryptionData: EncryptionData) {
+  // TODO: implement the actual segment decryption here
+  return encrypted;
+}

--- a/src/examples/segment-decryption/DecryptorProcessor.ts
+++ b/src/examples/segment-decryption/DecryptorProcessor.ts
@@ -1,0 +1,119 @@
+import { createTask } from '@bitmovin/player-web-x/playerx-framework-utils';
+import type {
+  SegmentDecryptor,
+  SegmentDecryptorData,
+  SegmentProcessorContext,
+} from '@bitmovin/player-web-x/types/packages/segment-processing/Types';
+
+import { decrypt } from './Decryption';
+import type { EncryptionData, EncryptionDataAtom } from './EncryptionDataAtom';
+import type { SegmentDecryptorPackageContext } from './Types';
+
+// A task that waits for the encryption data to become
+// available. Will resolve immediately, if the data is
+// already available and will block until it is otherwise.
+const WaitForEncryptionData = createTask(
+  'payload-awaiter',
+  async (payload: EncryptionDataAtom, context: SegmentProcessorContext) => {
+    const { effects, fork } = context;
+    const { abortable, state } = effects;
+
+    return abortable<EncryptionData>(resolve => {
+      const subscriber = createTask(
+        'payload-subscriber',
+        ({ value }: EncryptionDataAtom, _: SegmentProcessorContext) => {
+          if (value !== undefined) {
+            resolve(value);
+            unsubscribe();
+          }
+        },
+      );
+
+      const unsubscribe = state.subscribe(context, payload, subscriber);
+      fork(subscriber, payload);
+    });
+  },
+);
+
+// Creates a `SegmentDecryptor` processor that takes `Uint8Array`
+// network chunks as an input, decrypts those chunks and provides
+// decrypted `Uint8Array` chunks as an output.
+export function createDecryptorProcessor(
+  context: SegmentDecryptorPackageContext,
+  encryptionDataAtom: EncryptionDataAtom,
+) {
+  // Segment processors come in different types - the one
+  // implemented here is a `Decryptor` processor.
+  const SegmentProcessorType = context.registry.get('segment-processor-type');
+
+  // Each segment processor is executing a task that is provided
+  // with the segment processor data. The shape of that data
+  // depends on the type of the processor, but every processor
+  // gets reads from an `input` and writes to an `output`.
+  // In the case of a decryptor processor, both the input and the
+  // output are `Uint8Array`s.
+  const decryptorProcessor = createTask(
+    'decryptor-processor',
+    async (data: SegmentDecryptorData, context: SegmentProcessorContext) => {
+      const { state } = context.effects;
+      const { merge } = context.registry.get('utils').TypedArrays;
+      const { getReadableSegmentName } = context.registry.get('core-state-atoms').Segments;
+      const chunks: Uint8Array[] = [];
+      const { blue, cyan, bold } = context.registry.get('utils').AnsiEscapeSequences;
+      const logPrefix = `[${bold(blue('Decryption'))}] `;
+      const segmentName = bold(cyan(getReadableSegmentName(data.segment, 1)));
+      const logger = context.registry.get('logger');
+
+      logger.log(logPrefix + `Reading chunks for "${segmentName}"...`);
+
+      // It is possible to consume input data on a chunk-by-chunk
+      // basis, but for simplicity we will collect all chunks and
+      // merge them before starting the decryption process.
+      for await (const chunk of data.input) {
+        chunks.push(chunk);
+      }
+
+      logger.log(logPrefix + `Chunks for "${segmentName}" read, waiting for decryption data...`);
+
+      const mergedData = merge(chunks);
+
+      // Once all chunks were loaded and merged, we need to ensure
+      // that the information needed to decrypt those segments is
+      // available. We do this by waiting for the
+      // `EncryptionDataAtom` to be populated with data by the
+      // `BackendRequestTask` that is running in the background.
+      const encryptionData = await context.fork(WaitForEncryptionData, encryptionDataAtom);
+
+      logger.log(logPrefix + `Encryption data received, decrypting "${segmentName}"...`);
+
+      // Once the encryption data is available, we can decrypt
+      // the data.
+      const decryptedData = await decrypt(mergedData, encryptionData);
+
+      logger.log(logPrefix + `"${segmentName}" decrypted`);
+
+      // Finally, we write the decrypted data to the output, which
+      // will allow the processing component to continue processing
+      // the data contained with this segment.
+      state.dispatch(data.output.push, decryptedData);
+
+      // Once we've written all chunks to the output, we also need
+      // to close it to let the processor know, that we've
+      // processed all the data there is.
+      state.dispatch(data.output.close);
+    },
+  );
+
+  return {
+    name: 'my-custom-segment-decryptor',
+    type: SegmentProcessorType.Decryptor,
+
+    // The player currently does not extract the encryption format
+    // from the manifest, and it uses a hard-coded value
+    // internally instead. This will change in the future, but for
+    // now every segment decryptor must specify this hard-coded
+    // encryption format as it will not be executed otherwise.
+    supportedEncryptionFormats: ['😽'],
+    process: decryptorProcessor,
+  } as SegmentDecryptor;
+}

--- a/src/examples/segment-decryption/EncryptionDataAtom.ts
+++ b/src/examples/segment-decryption/EncryptionDataAtom.ts
@@ -1,0 +1,21 @@
+import type { EmptyObject } from '@bitmovin/player-web-x/framework-types/BaseTypes';
+import type { ContextHaving } from '@bitmovin/player-web-x/framework-types/execution-context/Types';
+import type { PrimitiveAtom } from '@bitmovin/player-web-x/types/packages/core/state/PrimitiveAtom';
+import type { CoreExportNames, CoreStateAtoms } from '@bitmovin/player-web-x/types/packages/core/Types';
+import type { ContextWithState } from '@bitmovin/player-web-x/types/packages/Types';
+
+export type EncryptionData = {
+  key: ArrayBuffer;
+  iv: ArrayBuffer;
+};
+
+export type EncryptionDataAtom = PrimitiveAtom<EncryptionData | undefined>;
+
+type ContextT = ContextHaving<{ [CoreExportNames.CoreStateAtoms]: CoreStateAtoms }, EmptyObject, ContextWithState>;
+
+// A `PrimitiveAtom` that holds the information needed to decrypt a segment.
+export function createEncryptionDataAtom(context: ContextT) {
+  const { createPrimitiveAtom } = context.registry.get('core-state-atoms');
+
+  return createPrimitiveAtom<EncryptionData | undefined>(context, undefined);
+}

--- a/src/examples/segment-decryption/SegmentDecryption.package.ts
+++ b/src/examples/segment-decryption/SegmentDecryption.package.ts
@@ -1,0 +1,49 @@
+import { createPackage } from '@bitmovin/player-web-x/playerx-framework-utils';
+import type { EmptyObject } from '@bitmovin/player-web-x/types/Types';
+
+import { BackendRequestTask } from './BackendRequestTask';
+import { createDecryptorProcessor } from './DecryptorProcessor';
+import { createEncryptionDataAtom } from './EncryptionDataAtom';
+import type { SegmentDecryptorPackageDependencies, SegmentDecryptorPackageExports } from './Types';
+
+// This package does two things:
+//  - it executes a `BackendRequestTask` that fetches some
+//    stream-specific encryption info from a backend and
+//  - it adds a `SegmentDecryptor` processor to the processing
+//    component that waits for the encryption data to be
+//    fetched from the backend and decrypts every segment,
+//    when the decryption data is available
+//
+// The package will be executed once for every source, so
+// the backend request will also be sent once per source.
+// However, the decryptor processor will be executed for
+// every segment as it is being downloaded.
+export const SegmentDecryptionPackage = createPackage<
+  SegmentDecryptorPackageDependencies,
+  SegmentDecryptorPackageExports,
+  EmptyObject
+>(
+  'segment-decryption-package',
+  (_, baseContext) => {
+    const { StateEffectFactory, EventListenerEffectFactory } = baseContext.registry.get('core-effects');
+    const context = baseContext.using(StateEffectFactory, EventListenerEffectFactory);
+    const encryptionDataAtom = createEncryptionDataAtom(context);
+    const decryptorProcessor = createDecryptorProcessor(context, encryptionDataAtom);
+    const segmentProcessingComponent = context.registry.get('segment-processing-component');
+
+    segmentProcessingComponent.addProcessor(decryptorProcessor);
+    context.fork(BackendRequestTask, encryptionDataAtom);
+  },
+  [
+    'utils',
+    'logger',
+    'core-effects',
+    'core-state-atoms',
+    'segment-processor-type',
+    'segment-processing-component',
+    'network-task',
+    'metrics',
+  ],
+);
+
+export default SegmentDecryptionPackage;

--- a/src/examples/segment-decryption/Types.ts
+++ b/src/examples/segment-decryption/Types.ts
@@ -1,0 +1,40 @@
+import type { ContextHaving } from '@bitmovin/player-web-x/framework-types/execution-context/Types';
+import type { BundleExportNames } from '@bitmovin/player-web-x/types/bundles/Types';
+import type { AdaptationExportNames } from '@bitmovin/player-web-x/types/packages/adaptation/Types';
+import type { MetricsAtom } from '@bitmovin/player-web-x/types/packages/core/metrics/MetricsAtom';
+import type { CoreEffects, CoreExportNames, CoreStateAtoms } from '@bitmovin/player-web-x/types/packages/core/Types';
+import type { Logger } from '@bitmovin/player-web-x/types/packages/core/utils/Logger';
+import type { CoreUtils } from '@bitmovin/player-web-x/types/packages/core/utils/Types';
+import type { NetworkTask } from '@bitmovin/player-web-x/types/packages/network/NetworkTask';
+import type { NetworkExportNames } from '@bitmovin/player-web-x/types/packages/network/Types';
+import type {
+  SegmentProcessingComponent,
+  SegmentProcessingExportNames,
+  SegmentProcessorType,
+} from '@bitmovin/player-web-x/types/packages/segment-processing/Types';
+import type { ContextWithState } from '@bitmovin/player-web-x/types/packages/Types';
+import type { EmptyObject } from '@bitmovin/player-web-x/types/Types';
+
+export type SegmentDecryptorPackageDependencies = {
+  [CoreExportNames.Utils]: CoreUtils;
+  [BundleExportNames.Logger]: Logger;
+  [CoreExportNames.CoreEffects]: CoreEffects;
+  [CoreExportNames.CoreStateAtoms]: CoreStateAtoms;
+  [SegmentProcessingExportNames.SegmentProcessorType]: typeof SegmentProcessorType;
+  [SegmentProcessingExportNames.SegmentProcessingComponent]: SegmentProcessingComponent;
+  [NetworkExportNames.NetworkTask]: typeof NetworkTask;
+  [AdaptationExportNames.Metrics]: MetricsAtom;
+};
+
+export type SegmentDecryptorPackageExports = EmptyObject;
+
+export type SegmentDecryptorPackageContext = ContextHaving<
+  SegmentDecryptorPackageDependencies,
+  SegmentDecryptorPackageExports,
+  ContextWithState
+>;
+
+export type EncryptionDataBackendResponse = {
+  keyBase64: string;
+  ivBase64: string;
+};

--- a/static/index.html
+++ b/static/index.html
@@ -77,6 +77,7 @@
     <script type="text/javascript" src="../out/playback-state.package.js"></script>
     <script type="text/javascript" src="../out/playlist.package.js"></script>
     <script type="text/javascript" src="../out/resize-tracker.package.js"></script>
+    <script type="text/javascript" src="../out/segment-decryption.package.js"></script>
 
     <style>
       .container .row {
@@ -229,6 +230,7 @@
       // player.packages.add(bitmovin.playerx['download-statistics'].default)
       // player.packages.add(bitmovin.playerx['playback-state'].default)
       // player.packages.add(bitmovin.playerx['resize-tracker'].default)
+      // player.packages.add(bitmovin.playerx['segment-decryption'].default)
       /**
        * The following code sets up the interaction with the page. You can safely ignore it.
        */


### PR DESCRIPTION
This PR adds a sample package that shows how a simple `SegmentDecryptor` processor can be implemented that requires some encryption information to be requested from a backend in order to decrypt segments.

No actual decryption mechanism is implemented in this sample, it merely shows how such a decryption mechanism could be implemented.