### PR TITLE
[Untracked] Update demos to new version of pwx

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@bitmovin/player-web-x": "^10.1.3"
+        "@bitmovin/player-web-x": "^10.2.0-beta.9"
       },
       "devDependencies": {
         "@types/node": "^20.3.2",
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@bitmovin/player-web-x": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@bitmovin/player-web-x/-/player-web-x-10.1.3.tgz",
-      "integrity": "sha512-gTZxKcjOk+Sc6RPXI8fgTTObO0RdIoK7ruM3ocgFmP3F7+8y03eqmnUEZj7H/otrHltrsvqucKgjzS8Gq8/ROg=="
+      "version": "10.2.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@bitmovin/player-web-x/-/player-web-x-10.2.0-beta.9.tgz",
+      "integrity": "sha512-/5fSaEta6CZL6+NQg7c/8DoOVDDSJP4YgNVSF1ww2EFggpe4wBfDaZXIwP6xYlzPMHW8TutEzBoybiJj8aTYQg=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -6777,6 +6777,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7468,9 +7469,9 @@
       "dev": true
     },
     "@bitmovin/player-web-x": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@bitmovin/player-web-x/-/player-web-x-10.1.3.tgz",
-      "integrity": "sha512-gTZxKcjOk+Sc6RPXI8fgTTObO0RdIoK7ruM3ocgFmP3F7+8y03eqmnUEZj7H/otrHltrsvqucKgjzS8Gq8/ROg=="
+      "version": "10.2.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@bitmovin/player-web-x/-/player-web-x-10.2.0-beta.9.tgz",
+      "integrity": "sha512-/5fSaEta6CZL6+NQg7c/8DoOVDDSJP4YgNVSF1ww2EFggpe4wBfDaZXIwP6xYlzPMHW8TutEzBoybiJj8aTYQg=="
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "webpack-plugin-serve": "^1.6.0"
   },
   "dependencies": {
-    "@bitmovin/player-web-x": "^10.1.3"
+    "@bitmovin/player-web-x": "^10.2.0-beta.9"
   }
 }

--- a/src/examples/buffer-ranges/BufferRangeObserver.package.ts
+++ b/src/examples/buffer-ranges/BufferRangeObserver.package.ts
@@ -1,20 +1,15 @@
 import type { ContextHaving } from '@bitmovin/player-web-x/framework-types/execution-context/Types';
 import { createPackage } from '@bitmovin/player-web-x/playerx-framework-utils';
-import type { BundleExportNames } from '@bitmovin/player-web-x/types/bundles/Types';
 import type { CoreEffects, CoreExportNames } from '@bitmovin/player-web-x/types/packages/core/Types';
-import type { Logger } from '@bitmovin/player-web-x/types/packages/core/utils/Logger';
-import type { SourceStateAtom } from '@bitmovin/player-web-x/types/packages/source/atoms/SourceStateAtom';
-import type { SourceExportNames } from '@bitmovin/player-web-x/types/packages/source/Types';
+import type { StreamingState } from '@bitmovin/player-web-x/types/packages/streaming/Types';
 import type { ContextWithState } from '@bitmovin/player-web-x/types/packages/Types';
 import type { EmptyObject } from '@bitmovin/player-web-x/types/Types';
 
 import { BufferRangeSubscriber } from './BufferRangeSubscriber';
 
 type Dependencies = {
-  [BundleExportNames.Logger]: Logger;
   [CoreExportNames.CoreEffects]: CoreEffects;
-  [SourceExportNames.SourceState]: SourceStateAtom;
-};
+} & StreamingState;
 
 type Exports = EmptyObject;
 
@@ -27,12 +22,12 @@ export const BufferRangeObserverPackage = createPackage<Dependencies, Exports, A
   (_, baseContext) => {
     const { StateEffectFactory, EventListenerEffectFactory } = baseContext.registry.get('core-effects');
     const context = baseContext.using(StateEffectFactory).using(EventListenerEffectFactory);
-    const sourceState = context.registry.get('source-state-atom');
+    const streamingState = context.registry.get('streaming-state');
     const { state } = context.effects;
 
-    state.subscribe(context, sourceState.dataRanges, BufferRangeSubscriber);
+    state.subscribe(context, streamingState.dataRanges, BufferRangeSubscriber);
   },
-  ['core-effects', 'source-state-atom'],
+  ['core-effects', 'streaming-state'],
 );
 
 export default BufferRangeObserverPackage;

--- a/src/examples/buffer-ranges/BufferRangeSubscriber.ts
+++ b/src/examples/buffer-ranges/BufferRangeSubscriber.ts
@@ -1,7 +1,7 @@
 import { createTask } from '@bitmovin/player-web-x/playerx-framework-utils';
 import type { MediaType } from '@bitmovin/player-web-x/types/packages/core/Constants';
-import type { DataRangesAtom } from '@bitmovin/player-web-x/types/packages/core/state/data-ranges/DataRangesAtom';
-import type { TimeRange } from '@bitmovin/player-web-x/types/packages/core/state/track/TrackAtom';
+import type { DataRangesAtom } from '@bitmovin/player-web-x/types/packages/streaming/atoms/DataRangesAtom';
+import type { TimeRange } from '@bitmovin/player-web-x/types/packages/stream-data-structure/track/TrackAtom';
 
 import type { BufferRangeObserverContext } from './BufferRangeObserver.package';
 
@@ -32,7 +32,7 @@ function prettyPrintBufferRanges(ranges: DataRangesAtom) {
 export const BufferRangeSubscriber = createTask(
   'buffer-range-observer',
   (ranges: DataRangesAtom, context: BufferRangeObserverContext) => {
-    const logger = context.registry.get('logger');
+    const logger = context.effects.logger;
 
     logger.warn(`Buffered ranges:\n${prettyPrintBufferRanges(ranges)}`);
   },

--- a/src/examples/hello-world/HelloWorld.package.ts
+++ b/src/examples/hello-world/HelloWorld.package.ts
@@ -3,17 +3,12 @@
  * This package will print the string `Hello World` to the console.
  */
 import { createPackage } from '@bitmovin/player-web-x/playerx-framework-utils';
-import type { BundleExportNames } from '@bitmovin/player-web-x/types/bundles/Types';
-import type { Logger } from '@bitmovin/player-web-x/types/packages/core/utils/Logger';
 import type { EmptyObject } from '@bitmovin/player-web-x/types/Types';
 
-// In order to do so, it needs to depend on the `Logger` of the player.
 // By convention, we define dependencies of a Package in a `*Dependencies` type.
-// This one defines that this package depends on a component named "logger" of
-// type `Logger`.
-type Dependencies = {
-  [BundleExportNames.Logger]: Logger;
-};
+// This package has no registry dependencies - it only uses the logger
+// which is available via the BaseContext effects.
+type Dependencies = EmptyObject;
 
 // Similarly, we use an `*Exports` type to define the components that are
 // exported by a package. This one doesn't export anything, so we can just
@@ -38,17 +33,15 @@ type Api = EmptyObject;
 //    `*Dependencies` type.
 export const HelloWorldPackage = createPackage<Dependencies, Exports, Api>(
   'hello-world-package',
-  (apiManager, context) => {
+  (_apiManager, context) => {
     // All components that this package depends on can be acquired from the
     // `Registry`. However, components that are exposed by a package can also
     // be acquired from the `Registry`, but trying to do so before they have
     // been exposed will cause an error to be thrown.
-    const logger = context.registry.get('logger' as BundleExportNames.Logger);
-
-    // Hello World! :)
-    logger.warn('Hello World!');
+    
+    context.effects.logger.warn('Hello World!');
   },
-  ['logger' as BundleExportNames.Logger],
+  [],
 );
 
 // Finally, we also want to use a default export so that all packages can be

--- a/src/examples/playback-state/PlaybackState.package.ts
+++ b/src/examples/playback-state/PlaybackState.package.ts
@@ -2,10 +2,8 @@ import type { Abortable } from '@bitmovin/player-web-x/framework-types/abortable
 import type { EmptyObject } from '@bitmovin/player-web-x/framework-types/BaseTypes';
 import type { ContextHaving, ContextUsing } from '@bitmovin/player-web-x/framework-types/execution-context/Types';
 import { createPackage, createTask } from '@bitmovin/player-web-x/playerx-framework-utils';
-import type { BundleExportNames } from '@bitmovin/player-web-x/types/bundles/Types';
 import type { StoreEffectFactory } from '@bitmovin/player-web-x/types/packages/core/state/StoreEffectFactory';
 import type { CoreEffects, CoreExportNames } from '@bitmovin/player-web-x/types/packages/core/Types';
-import type { Logger } from '@bitmovin/player-web-x/types/packages/core/utils/Logger';
 import type { SourceStateAtom } from '@bitmovin/player-web-x/types/packages/source/atoms/SourceStateAtom';
 import type { VideoElementAtom } from '@bitmovin/player-web-x/types/packages/source/atoms/VideoElementAtom';
 import type { SourceExportNames } from '@bitmovin/player-web-x/types/packages/source/Types';
@@ -17,7 +15,6 @@ import type { PlaybackStatePackageExports } from './Types';
 import { PlaybackStateExportNames } from './Types';
 
 type Dependencies = {
-  [BundleExportNames.Logger]: Logger;
   [CoreExportNames.CoreEffects]: CoreEffects;
   [SourceExportNames.SourceState]: SourceStateAtom;
 };
@@ -36,7 +33,7 @@ export type PlaybackStateContext = ContextHaving<
  * PlaybackStatePackage
  *
  * Exports `PlaybackStateAtom` which is updated inside the package to the correct state based on VideoElement events.
- * Will get executed when [source-state, core-effects, logger] are available
+ * Will get executed when [source-state, core-effects] are available
  */
 export const PlaybackStatePackage = createPackage<Dependencies, PlaybackStatePackageExports, EmptyObject>(
   'playback-state-package',
@@ -78,13 +75,14 @@ export const PlaybackStatePackage = createPackage<Dependencies, PlaybackStatePac
       contextWithPlaybackState,
       playbackStateAtom,
       createTask('playback-state-subscriber', (playbackState: PlaybackStateAtom, context: PlaybackStateContext) => {
-        const logger = context.registry.get('logger');
+        const logger = context.effects.logger;
+        const sourceUrl = sourceState.sourceConfig.resources[0]?.url ?? 'unknown';
 
         if (playbackState.state === Playback.Suspended) {
-          logger.log(`[Playback suspended]: ${sourceState.url}`);
+          logger.log(`[Playback suspended]: ${sourceUrl}`);
         } else {
           const { playhead, duration, playbackRate, state } = playbackState;
-          logger.log(`[PlaybackState changed]: ${sourceState.url}`, {
+          logger.log(`[PlaybackState changed]: ${sourceUrl}`, {
             state,
             playhead,
             duration,
@@ -94,10 +92,7 @@ export const PlaybackStatePackage = createPackage<Dependencies, PlaybackStatePac
       }),
     );
   },
-  ['core-effects', 'source-state-atom', 'logger'],
-
-  // Package is considered a `Task`, but we do not need to return loop in it, as it will by default it will add
-  // one more step that returns loop
+  ['core-effects', 'source-state-atom'],
 );
 
 const VideoElementSubscriber = (initialAbortable?: Abortable) =>
@@ -120,9 +115,6 @@ const VideoElementSubscriber = (initialAbortable?: Abortable) =>
     const isPlaying = () => !video.paused && !video.ended;
 
     state.dispatch(playbackState.onPlaybackRateChange, video.playbackRate);
-    // Using EventListenerEffect, subscribe and dispatch correct state changes.
-    // This ensures structured concurrency is honored, as the listeners will be automatically removed once the thread
-    // has finished running.
     events.subscribe(context, video, 'timeupdate', () => state.dispatch(playbackState.onTimeupdate, video.currentTime));
     events.subscribe(context, video, 'durationchange', () =>
       state.dispatch(playbackState.onDurationChange, video.duration),
@@ -138,9 +130,6 @@ const VideoElementSubscriber = (initialAbortable?: Abortable) =>
     events.subscribe(context, video, 'pause', () => state.dispatch(playbackState.onPaused));
     events.subscribe(context, video, 'ended', () => state.dispatch(playbackState.onEnded));
 
-    // Returning loop ensures this task never finishes running until it is terminated by the parent.
-    // If it had finished running, it would have removed subscribers above, as they are children of this thread
-    // which was started with this task.
     return context.effects.loop(context.abortSignal);
   });
 

--- a/src/examples/playlist/Playlist.package.ts
+++ b/src/examples/playlist/Playlist.package.ts
@@ -1,9 +1,7 @@
 import type { EmptyObject } from '@bitmovin/player-web-x/framework-types/BaseTypes';
 import { createPackage, createTask, createTaskClosure } from '@bitmovin/player-web-x/playerx-framework-utils';
-import type { BundleExportNames } from '@bitmovin/player-web-x/types/bundles/Types';
 import type { StateAtom } from '@bitmovin/player-web-x/types/packages/core/state/Types';
 import type { CoreEffects, CoreExportNames, CoreStateAtoms } from '@bitmovin/player-web-x/types/packages/core/Types';
-import type { Logger } from '@bitmovin/player-web-x/types/packages/core/utils/Logger';
 import type { VideoElementAtom } from '@bitmovin/player-web-x/types/packages/source/atoms/VideoElementAtom';
 import type {
   SourceExportNames,
@@ -16,7 +14,6 @@ import type { ContextWithState } from '@bitmovin/player-web-x/types/packages/Typ
 export const PlaylistPackageThreadName = 'playlist-package-thread';
 
 export type PlaylistPackageDependencies = {
-  [BundleExportNames.Logger]: Logger;
   [CoreExportNames.CoreEffects]: CoreEffects;
   [CoreExportNames.CoreStateAtoms]: CoreStateAtoms;
   [SourceExportNames.SourceReferences]: SourceReferences;
@@ -64,7 +61,7 @@ const sourcesChangeTask = createTask(
 export const PlaylistPackage = createPackage<PlaylistPackageDependencies, EmptyObject, PlaylistAPI>(
   'playlist-package',
   (apiManager, ctx) => {
-    const logger = ctx.registry.get('logger');
+    const logger = ctx.effects.logger;
     const sourceReferences = ctx.registry.get('source-references');
     const { StateEffectFactory, EventListenerEffectFactory } = ctx.registry.get('core-effects');
     const sourcesContext = ctx.using(StateEffectFactory).using(EventListenerEffectFactory);
@@ -75,7 +72,7 @@ export const PlaylistPackage = createPackage<PlaylistPackageDependencies, EmptyO
 
     sourcesContext.effects.state.subscribe(sourcesContext, sourceReferences, sourcesChangeTask);
   },
-  ['logger', 'core-effects', 'core-state-atoms', 'source-references'],
+  ['core-effects', 'core-state-atoms', 'source-references'],
 );
 
 function createPlaylistAPI(ctx: ContextWithState, sourceReferences: SourceReferences, api: PlaylistAPI) {
@@ -116,7 +113,7 @@ const onSourcesChangeTask = createTaskClosure(
 function mapSourcesForCallback(references: SourceReferences) {
   return references.map(reference => {
     return {
-      url: reference.state.url,
+      url: reference.config.resources[0]?.url ?? 'unknown',
       id: reference.id,
       active: Boolean(reference.state.video.element),
     };

--- a/src/examples/resize-tracker/ResizeTracker.package.ts
+++ b/src/examples/resize-tracker/ResizeTracker.package.ts
@@ -2,10 +2,8 @@ import type { Abortable } from '@bitmovin/player-web-x/framework-types/abortable
 import type { EmptyObject } from '@bitmovin/player-web-x/framework-types/BaseTypes';
 import type { ContextHaving, ContextUsing } from '@bitmovin/player-web-x/framework-types/execution-context/Types';
 import { createPackage, createTask } from '@bitmovin/player-web-x/playerx-framework-utils';
-import type { BundleExportNames } from '@bitmovin/player-web-x/types/bundles/Types';
 import type { StoreEffectFactory } from '@bitmovin/player-web-x/types/packages/core/state/StoreEffectFactory';
 import type { CoreEffects, CoreExportNames } from '@bitmovin/player-web-x/types/packages/core/Types';
-import type { Logger } from '@bitmovin/player-web-x/types/packages/core/utils/Logger';
 import type { SourceStateAtom } from '@bitmovin/player-web-x/types/packages/source/atoms/SourceStateAtom';
 import type { VideoElementAtom } from '@bitmovin/player-web-x/types/packages/source/atoms/VideoElementAtom';
 import type { SourceExportNames } from '@bitmovin/player-web-x/types/packages/source/Types';
@@ -19,7 +17,6 @@ import { createResizeTrackerStateAtom } from './ResizeTrackerStateAtom';
 type Dependencies = {
   [CoreExportNames.CoreEffects]: CoreEffects;
   [SourceExportNames.SourceState]: SourceStateAtom;
-  [BundleExportNames.Logger]: Logger;
 };
 
 export enum ResizeTrackerExportNames {
@@ -63,7 +60,7 @@ export const ResizeTrackerPackage = createPackage<Dependencies, ResizeTrackerExp
     });
     state.subscribe(contextWithVideoState, sourceState.video, VideoElementSubscriber(initial));
   },
-  ['core-effects', 'source-state-atom', 'logger'],
+  ['core-effects', 'source-state-atom'],
 );
 
 const VideoElementSubscriber = (initialAbortable?: Abortable) =>
@@ -80,7 +77,7 @@ const VideoElementSubscriber = (initialAbortable?: Abortable) =>
     const { state, store, resize } = context.effects;
     const { resizeTrackerState } = store;
 
-    const logger = context.registry.get('logger');
+    const logger = context.effects.logger;
 
     resize.subscribe(video, entry => {
       logger.log('[RT]', entry);

--- a/src/examples/segment-decryption/BackendRequestTask.ts
+++ b/src/examples/segment-decryption/BackendRequestTask.ts
@@ -37,8 +37,7 @@ async function fetchEncryptionData(context: SegmentDecryptorPackageContext) {
 export const BackendRequestTask = createTask(
   'backend-request-package',
   async (encryptionDataAtom: EncryptionDataAtom, context: SegmentDecryptorPackageContext) => {
-    const { state } = context.effects;
-    const logger = context.registry.get('logger');
+    const { state, logger } = context.effects;
     const { red, bold } = context.registry.get('utils').AnsiEscapeSequences;
     const logPrefix = `[${bold(red('Backend'))}] `;
 

--- a/src/examples/segment-decryption/DecryptorProcessor.ts
+++ b/src/examples/segment-decryption/DecryptorProcessor.ts
@@ -55,14 +55,13 @@ export function createDecryptorProcessor(
   const decryptorProcessor = createTask(
     'decryptor-processor',
     async (data: SegmentDecryptorData, context: SegmentProcessorContext) => {
-      const { state } = context.effects;
+      const { state, logger } = context.effects;
       const { merge } = context.registry.get('utils').TypedArrays;
-      const { getReadableSegmentName } = context.registry.get('core-state-atoms').Segments;
+      const { getReadableSegmentName } = context.registry.get('stream-data-structure-segments');
       const chunks: Uint8Array[] = [];
       const { blue, cyan, bold } = context.registry.get('utils').AnsiEscapeSequences;
       const logPrefix = `[${bold(blue('Decryption'))}] `;
       const segmentName = bold(cyan(getReadableSegmentName(data.segment, 1)));
-      const logger = context.registry.get('logger');
 
       logger.log(logPrefix + `Reading chunks for "${segmentName}"...`);
 

--- a/src/examples/segment-decryption/SegmentDecryption.package.ts
+++ b/src/examples/segment-decryption/SegmentDecryption.package.ts
@@ -36,7 +36,6 @@ export const SegmentDecryptionPackage = createPackage<
   },
   [
     'utils',
-    'logger',
     'core-effects',
     'core-state-atoms',
     'segment-processor-type',

--- a/src/examples/segment-decryption/Types.ts
+++ b/src/examples/segment-decryption/Types.ts
@@ -1,9 +1,7 @@
 import type { ContextHaving } from '@bitmovin/player-web-x/framework-types/execution-context/Types';
-import type { BundleExportNames } from '@bitmovin/player-web-x/types/bundles/Types';
 import type { AdaptationExportNames } from '@bitmovin/player-web-x/types/packages/adaptation/Types';
 import type { MetricsAtom } from '@bitmovin/player-web-x/types/packages/core/metrics/MetricsAtom';
 import type { CoreEffects, CoreExportNames, CoreStateAtoms } from '@bitmovin/player-web-x/types/packages/core/Types';
-import type { Logger } from '@bitmovin/player-web-x/types/packages/core/utils/Logger';
 import type { CoreUtils } from '@bitmovin/player-web-x/types/packages/core/utils/Types';
 import type { NetworkTask } from '@bitmovin/player-web-x/types/packages/network/NetworkTask';
 import type { NetworkExportNames } from '@bitmovin/player-web-x/types/packages/network/Types';
@@ -17,7 +15,6 @@ import type { EmptyObject } from '@bitmovin/player-web-x/types/Types';
 
 export type SegmentDecryptorPackageDependencies = {
   [CoreExportNames.Utils]: CoreUtils;
-  [BundleExportNames.Logger]: Logger;
   [CoreExportNames.CoreEffects]: CoreEffects;
   [CoreExportNames.CoreStateAtoms]: CoreStateAtoms;
   [SegmentProcessingExportNames.SegmentProcessorType]: typeof SegmentProcessorType;

--- a/src/examples/subtitles/ttml/SubscribeAndParse.ts
+++ b/src/examples/subtitles/ttml/SubscribeAndParse.ts
@@ -2,12 +2,12 @@ import { createTask, createTaskClosure } from '@bitmovin/player-web-x/playerx-fr
 import type { SubtitleFormatType } from '@bitmovin/player-web-x/types/packages/core/Constants';
 import type { ArrayAtom } from '@bitmovin/player-web-x/types/packages/core/state/ArrayStateAtom';
 import type { PrimitiveAtom } from '@bitmovin/player-web-x/types/packages/core/state/PrimitiveAtom';
-import type { DataOrSelfInitSegmentAtom } from '@bitmovin/player-web-x/types/packages/core/state/segment/SegmentAtom';
+import type { StreamSectionAtom } from '@bitmovin/player-web-x/types/packages/core/state/stream-timeline/StreamSectionAtom';
+import type { DataOrSelfInitSegmentAtom } from '@bitmovin/player-web-x/types/packages/stream-data-structure/segment/SegmentAtom';
 import type {
   SelectionGroupAtom,
   SubtitleSelectionGroupAtom,
-} from '@bitmovin/player-web-x/types/packages/core/state/selection-group/SelectionGroupAtom';
-import type { StreamSectionAtom } from '@bitmovin/player-web-x/types/packages/core/state/stream-timeline/StreamSectionAtom';
+} from '@bitmovin/player-web-x/types/packages/stream-data-structure/selection-group/SelectionGroupAtom';
 import type { SubtitleCueAtom } from '@bitmovin/player-web-x/types/packages/subtitles/subtitle-base/SubtitleCueAtom';
 
 import type { TTMLPackageContext } from './Types';
@@ -31,10 +31,8 @@ const StreamSequenceSubscribeTask = createTask(
     context: TTMLPackageContext,
   ) => {
     const subtitleCueMapAtom = context.registry.get('subtitle-cue-map-atom');
-    const {
-      createTimelineAtom,
-      SelectionGroups: { isSubtitleSelectionGroup },
-    } = context.registry.get('core-state-atoms');
+    const { createTimelineAtom } = context.registry.get('core-state-atoms');
+    const { isSubtitleSelectionGroup } = context.registry.get('stream-data-structure-selection-groups');
     const { subscribeAndRun } = context.registry.get('utils').State;
 
     // Ensure we are working only with subtitle selection groups

--- a/src/examples/subtitles/ttml/Ttml.package.ts
+++ b/src/examples/subtitles/ttml/Ttml.package.ts
@@ -23,6 +23,7 @@ const TtmlPackage = createPackage<TTMLDependencies, TTMLExports, EmptyObject>(
     'create-subtitle-cue-map-atom',
     'source-state-atom',
     'stream-timeline',
+    'stream-data-structure-selection-groups',
   ],
 );
 

--- a/src/examples/subtitles/ttml/Types.ts
+++ b/src/examples/subtitles/ttml/Types.ts
@@ -4,12 +4,13 @@ import type { Constants } from '@bitmovin/player-web-x/types/packages/core/Const
 import type { StreamTimelineAtom } from '@bitmovin/player-web-x/types/packages/core/state/stream-timeline/StreamTimelineMapAtom';
 import type { CoreEffects, CoreExportNames, CoreStateAtoms } from '@bitmovin/player-web-x/types/packages/core/Types';
 import type { CoreUtils } from '@bitmovin/player-web-x/types/packages/core/utils/Types';
-import type { DataExportNames } from '@bitmovin/player-web-x/types/packages/data/Types';
 import type { SourceStateAtom } from '@bitmovin/player-web-x/types/packages/source/atoms/SourceStateAtom';
 import type { SourceExportNames } from '@bitmovin/player-web-x/types/packages/source/Types';
+import type { StreamDataStructureSelectionGroups } from '@bitmovin/player-web-x/types/packages/stream-data-structure/selection-group/Exports';
 import type { createSubtitleCueAtom } from '@bitmovin/player-web-x/types/packages/subtitles/subtitle-base/SubtitleCueAtom';
 import type { SubtitleCueMapAtom } from '@bitmovin/player-web-x/types/packages/subtitles/subtitle-base/SubtitleCueMapAtom';
 import type { SubtitleBaseExportNames } from '@bitmovin/player-web-x/types/packages/subtitles/subtitle-base/Types';
+import type { DataExportNames } from '@bitmovin/player-web-x/types/packages/data/Types';
 import type { ContextWithState } from '@bitmovin/player-web-x/types/packages/Types';
 
 export type TTMLDependencies = {
@@ -21,7 +22,9 @@ export type TTMLDependencies = {
   [SubtitleBaseExportNames.CreateSubtitleCueAtom]: typeof createSubtitleCueAtom;
   [SourceExportNames.SourceState]: SourceStateAtom;
   [DataExportNames.StreamTimeline]: StreamTimelineAtom;
+  'stream-data-structure-selection-groups': StreamDataStructureSelectionGroups['stream-data-structure-selection-groups'];
 };
+
 export type TTMLExports = EmptyObject;
 
 export type TTMLPackageContext = ContextHaving<TTMLDependencies, TTMLExports, ContextWithState>;

--- a/static/index.html
+++ b/static/index.html
@@ -13,58 +13,10 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css" />
 
     <!--
-    Here we load the framework core source file, followed by the packages which compose the player .
+    Here we load the HLS bundle which includes all packages needed for HLS playback.
   -->
 
-    <script type="text/javascript" src="../node_modules/@bitmovin/player-web-x/bundles/playerx-core.js"></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-capabilities.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-segment-processing.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-container-mp4.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-data.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-network.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-hls-translation.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-hls-parsing.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-hls.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-presentation.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-source.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-sources-api.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-adaptation.package.js"
-    ></script>
+    <script type="text/javascript" src="../node_modules/@bitmovin/player-web-x/bundles/playerx-hls.js"></script>
     <!--
 
    Load the example package files
@@ -202,22 +154,10 @@
       });
 
       /**
-       * Load the player packages into the framework.
+       * Load custom example packages into the framework.
+       * The HLS bundle already includes all core player packages.
        */
       console.log('adding packages');
-      player.packages.add(bitmovin.playerx['capabilities'].default);
-      player.packages.add(bitmovin.playerx['segment-processing'].default);
-      player.packages.add(bitmovin.playerx['container-mp4'].default);
-      player.packages.add(bitmovin.playerx['data'].default);
-      player.packages.add(bitmovin.playerx['network'].default);
-      player.packages.add(bitmovin.playerx['hls-translation'].default);
-      player.packages.add(bitmovin.playerx['hls-parsing'].default);
-      player.packages.add(bitmovin.playerx['hls'].default);
-      player.packages.add(bitmovin.playerx['presentation'].default);
-      player.packages.add(bitmovin.playerx['source'].default);
-      player.packages.add(bitmovin.playerx['sources-api'].default);
-      player.packages.add(bitmovin.playerx['adaptation'].default);
-
       player.packages.add(bitmovin.playerx['playlist'].default);
 
       /**
@@ -299,7 +239,7 @@
         if (!sourceUrl) return;
 
         const sourceApi = player.sources.add(
-          { resources: [{ url: sourceUrl }] },
+          { resources: [{ url: sourceUrl, type: 'hls' }] },
           { attach: true, playback: { autoplay: true, muted: true } },
         );
 

--- a/static/overlay-example.html
+++ b/static/overlay-example.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css">
-    <script type="text/javascript" src="https://cdn.bitmovin.com/player/web_x/beta/10/bundles/playerx-hls.js"></script>
-    <script type="text/javascript" src="https://cdn.bitmovin.com/player/web_x/beta/10/playerx-framework-utils.js"></script>
+    <script type="text/javascript" src="../node_modules/@bitmovin/player-web-x/bundles/playerx-hls.js"></script>
+    <script type="text/javascript" src="../node_modules/@bitmovin/player-web-x/playerx-framework-utils.js"></script>
     <style>
         body {
             background-color: rgb(238, 246, 249);
@@ -67,6 +67,7 @@
       // Manager as well as a base Context that has no
       // other effects applied.
       (_apiManager, baseContext) => {
+        console.warn('Running overlay example')
         let removeOverlay = () => undefined;
 
         // As the supplied context is only a base Context, but we need both the `StateEffect`
@@ -106,7 +107,7 @@
         // the subscribed task will be run, thereby adding or removing the overlay.
         state.subscribe(context, sourceState.video, videoElementSubscriber);
       },
-      ['core-effects', 'source-state-atom', 'logger'],
+      ['core-effects', 'source-state-atom'],
     );
 
     // This function adds an overlay to the video element which displays the message.
@@ -122,7 +123,7 @@
 
       // We also want to log some messages to the console, so while we're at it,
       // let's get a reference to the Logger as well.
-      const logger = context.registry.get('logger');
+      const logger = context.effects.logger;
 
       const container = video.parentElement;
       const overlay = document.createElement('div');
@@ -183,7 +184,7 @@
     player.packages.add(OverlayPackage);
 
     // Finally, load the source we want to play back
-    player.sources.add({resources: [{url: source}]}, {attach: true, playback: {autoplay: true, muted: true}});
+    player.sources.add({resources: [{url: source, type: 'hls'}]}, {attach: true, playback: {autoplay: true, muted: true}});
 </script>
 </body>
 </html>

--- a/static/playlist.html
+++ b/static/playlist.html
@@ -15,55 +15,7 @@
       Here we load the framework core source file, followed by the packages which compose the player .
     -->
 
-    <script type="text/javascript" src="../node_modules/@bitmovin/player-web-x/bundles/playerx-core.js"></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-capabilities.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-segment-processing.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-container-mp4.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-data.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-network.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-hls-translation.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-hls-parsing.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-hls.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-presentation.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-source.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-sources-api.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-adaptation.package.js"
-    ></script>
+    <script type="text/javascript" src="../node_modules/@bitmovin/player-web-x/bundles/playerx-hls.js"></script>
     <script type="text/javascript" src="../out/playlist.package.js"></script>
 
     <style>
@@ -167,19 +119,6 @@
         defaultContainer: document.getElementById('player-container'),
       });
 
-      player.packages.add(bitmovin.playerx['capabilities'].default);
-      player.packages.add(bitmovin.playerx['segment-processing'].default);
-      player.packages.add(bitmovin.playerx['container-mp4'].default);
-      player.packages.add(bitmovin.playerx['data'].default);
-      player.packages.add(bitmovin.playerx['network'].default);
-      player.packages.add(bitmovin.playerx['hls-translation'].default);
-      player.packages.add(bitmovin.playerx['hls-parsing'].default);
-      player.packages.add(bitmovin.playerx['hls'].default);
-      player.packages.add(bitmovin.playerx['presentation'].default);
-      player.packages.add(bitmovin.playerx['source'].default);
-      player.packages.add(bitmovin.playerx['sources-api'].default);
-      player.packages.add(bitmovin.playerx['adaptation'].default);
-
       player.packages.add(bitmovin.playerx['playlist'].default);
 
       const allSourcesMap = {
@@ -234,7 +173,7 @@
         if (!sourceUrl) return;
 
         const sourceApi = player.sources.add(
-          { resources: [{ url: sourceUrl }] },
+          { resources: [{ url: sourceUrl, type: 'hls' }] },
           { attach: true, playback: { autoplay: true, muted: true } },
         );
 

--- a/static/subtitles-modular.html
+++ b/static/subtitles-modular.html
@@ -12,65 +12,9 @@
     />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css" />
 
-    <!-- Here we load the framework core source file, followed by the packages which compose the player. -->
+    <!-- Here we load the HLS bundle which includes all packages needed for HLS playback. -->
 
-    <script type="text/javascript" src="../node_modules/@bitmovin/player-web-x/bundles/playerx-core.js"></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-capabilities.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-segment-processing.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-container-mp4.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-container-ts.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-ts-transmuxer.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-data.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-network.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-hls-translation.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-hls-parsing.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-hls.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-presentation.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-source.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-sources-api.package.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="../node_modules/@bitmovin/player-web-x/packages/playerx-adaptation.package.js"
-    ></script>
+    <script type="text/javascript" src="../node_modules/@bitmovin/player-web-x/bundles/playerx-hls.js"></script>
     <script
       type="text/javascript"
       src="../node_modules/@bitmovin/player-web-x/packages/playerx-subtitles.package.js"
@@ -133,21 +77,7 @@
        * Load the player packages into the framework.
        */
       console.log('adding packages');
-      player.packages.add(bitmovin.playerx['capabilities'].default);
-      player.packages.add(bitmovin.playerx['segment-processing'].default);
-      player.packages.add(bitmovin.playerx['container-mp4'].default);
-      player.packages.add(bitmovin.playerx['container-ts'].default);
-      player.packages.add(bitmovin.playerx['ts-transmuxer'].default);
-      player.packages.add(bitmovin.playerx['data'].default);
-      player.packages.add(bitmovin.playerx['network'].default);
-      player.packages.add(bitmovin.playerx['hls-translation'].default);
-      player.packages.add(bitmovin.playerx['hls-parsing'].default);
-      player.packages.add(bitmovin.playerx['hls'].default);
-      player.packages.add(bitmovin.playerx['presentation'].default);
-      player.packages.add(bitmovin.playerx['source'].default);
-      player.packages.add(bitmovin.playerx['sources-api'].default);
-      player.packages.add(bitmovin.playerx['adaptation'].default);
-      // Add subtitle packages
+      // Add subtitle packages (HLS bundle is auto-registered)
       player.packages.add(bitmovin.playerx['subtitles'].default);
       // Adding custom format detection package
       player.packages.add(bitmovin.playerx['subtitle-format-detection-modify'].default);
@@ -156,7 +86,7 @@
 
       // Current source has WebVTT subtitles
       const sourceApi = player.sources.add(
-        { resources: [{ url: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8' }] },
+        { resources: [{ url: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8', type: 'hls' }] },
         { attach: true, playback: { autoplay: true, muted: true } },
       );
       sourceApi.logLevel = 1e9;

--- a/static/subtitles.html
+++ b/static/subtitles.html
@@ -70,7 +70,7 @@
 
       // Current source has WebVTT subtitles
       const sourceApi = player.sources.add(
-        { resources: [{ url: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8' }] },
+        { resources: [{ url: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8', type: 'hls' }] },
         { attach: true, playback: { autoplay: true, muted: true } },
       );
       sourceApi.logLevel = 1e9;


### PR DESCRIPTION
- Updated player-web-x from 10.1.3 to 10.2.0-beta.9, adapting to API changes (logger moved to BaseContext effects, streaming-state replaces source-state-atom for buffer ranges, new stream-data-structure-selection-groups dependency for subtitles)
- Removed Logger as an explicit registry dependency across all packages since it's now available via context.effects.logger